### PR TITLE
add --local-content-can-access-remote-urls flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.clickable
+/build

--- a/RSSreader.desktop
+++ b/RSSreader.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=RSS Reader
 Comment=A clean RSS Reader
-Exec=webapp-container ./www/index.html
+Exec=webapp-container --local-content-can-access-remote-urls ./www/index.html
 Icon=RSSreader.png
 Terminal=false
 Type=Application

--- a/clickable.json
+++ b/clickable.json
@@ -1,0 +1,4 @@
+{
+  "template":"pure",
+  "dependencies":["morph-webapp-container", "morph-browser"]
+}

--- a/clickable.json
+++ b/clickable.json
@@ -1,4 +1,3 @@
 {
-  "template":"pure",
-  "dependencies":["morph-webapp-container", "morph-browser"]
+  "template" : "pure"
 }


### PR DESCRIPTION
without that the chromium web security does not let the local app (file:///) access the feed urls

see https://github.com/ubports/morph-browser/issues/44 

add clickable.json and .gitignore